### PR TITLE
Add unit tests for bridge loader, TransferPdu policies, BridgeConnection and BridgeCore

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,0 +1,26 @@
+set(TEST_SOURCES
+    bridge_loader_test.cpp
+    transfer_pdu_test.cpp
+    bridge_connection_test.cpp
+    bridge_core_test.cpp
+)
+
+add_executable(hakoniwa_pdu_bridge_tests ${TEST_SOURCES})
+
+target_include_directories(hakoniwa_pdu_bridge_tests
+    PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}
+)
+
+target_compile_definitions(hakoniwa_pdu_bridge_tests
+    PRIVATE
+        TEST_CONFIG_DIR="${CMAKE_CURRENT_SOURCE_DIR}/config"
+)
+
+target_link_libraries(hakoniwa_pdu_bridge_tests
+    PRIVATE
+        hakoniwa_pdu_bridge_lib
+        gtest_main
+)
+
+add_test(NAME hakoniwa_pdu_bridge_tests COMMAND hakoniwa_pdu_bridge_tests)

--- a/test/bridge_connection_test.cpp
+++ b/test/bridge_connection_test.cpp
@@ -1,0 +1,51 @@
+#include "hakoniwa/pdu/bridge/bridge_connection.hpp"
+#include "hakoniwa/pdu/bridge/policy/immediate_policy.hpp"
+#include "hakoniwa/pdu/bridge/transfer_pdu.hpp"
+#include "hakoniwa/pdu/bridge/virtual_time_source.hpp"
+
+#include "mock_endpoint.hpp"
+
+#include <gtest/gtest.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <memory>
+#include <vector>
+
+namespace hako::pdu::bridge::test {
+
+namespace {
+std::vector<std::byte> make_payload(uint64_t epoch, size_t size) {
+    std::vector<std::byte> payload(size);
+    std::memcpy(payload.data(), &epoch, sizeof(epoch));
+    return payload;
+}
+
+hakoniwa::pdu::PduKey make_endpoint_key(const std::string& robot, const std::string& pdu) {
+    return hakoniwa::pdu::PduKey{robot, pdu};
+}
+} // namespace
+
+TEST(BridgeConnectionTest, StepTransfersAllPdus) {
+    auto time_source = std::make_shared<VirtualTimeSource>();
+    auto policy = std::make_shared<ImmediatePolicy>();
+    auto src = std::make_shared<test_support::MockEndpoint>("src");
+    auto dst = std::make_shared<test_support::MockEndpoint>("dst");
+
+    src->set_pdu_data(make_endpoint_key("Robot1", "pos"), make_payload(1U, 16U));
+    src->set_pdu_data(make_endpoint_key("Robot1", "status"), make_payload(1U, 16U));
+
+    BridgeConnection connection("node1");
+    connection.add_transfer_pdu(std::make_unique<TransferPdu>(
+        PduKey{"Robot1.pos", "Robot1", "pos"}, policy, src, dst));
+    connection.add_transfer_pdu(std::make_unique<TransferPdu>(
+        PduKey{"Robot1.status", "Robot1", "status"}, policy, src, dst));
+
+    connection.step(time_source);
+
+    EXPECT_EQ(dst->send_count(make_endpoint_key("Robot1", "pos")), 1U);
+    EXPECT_EQ(dst->send_count(make_endpoint_key("Robot1", "status")), 1U);
+}
+
+} // namespace hako::pdu::bridge::test

--- a/test/bridge_core_test.cpp
+++ b/test/bridge_core_test.cpp
@@ -1,0 +1,69 @@
+#include "hakoniwa/pdu/bridge/bridge_connection.hpp"
+#include "hakoniwa/pdu/bridge/bridge_core.hpp"
+#include "hakoniwa/pdu/bridge/policy/immediate_policy.hpp"
+#include "hakoniwa/pdu/bridge/transfer_pdu.hpp"
+#include "hakoniwa/pdu/bridge/virtual_time_source.hpp"
+
+#include "mock_endpoint.hpp"
+
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <memory>
+#include <thread>
+#include <vector>
+
+namespace hako::pdu::bridge::test {
+
+namespace {
+std::vector<std::byte> make_payload(uint64_t epoch, size_t size) {
+    std::vector<std::byte> payload(size);
+    std::memcpy(payload.data(), &epoch, sizeof(epoch));
+    return payload;
+}
+
+hakoniwa::pdu::PduKey make_endpoint_key(const std::string& robot, const std::string& pdu) {
+    return hakoniwa::pdu::PduKey{robot, pdu};
+}
+
+std::unique_ptr<BridgeConnection> make_connection(const std::string& node_id,
+                                                  const std::shared_ptr<test_support::MockEndpoint>& src,
+                                                  const std::shared_ptr<test_support::MockEndpoint>& dst,
+                                                  const std::string& pdu_name) {
+    auto policy = std::make_shared<ImmediatePolicy>();
+    auto connection = std::make_unique<BridgeConnection>(node_id);
+    connection->add_transfer_pdu(std::make_unique<TransferPdu>(
+        PduKey{"Robot1." + pdu_name, "Robot1", pdu_name}, policy, src, dst));
+    return connection;
+}
+} // namespace
+
+TEST(BridgeCoreTest, RunLoopStepsMultipleConnections) {
+    auto time_source = std::make_shared<VirtualTimeSource>();
+    BridgeCore core("node1", time_source);
+
+    auto src1 = std::make_shared<test_support::MockEndpoint>("src1");
+    auto dst1 = std::make_shared<test_support::MockEndpoint>("dst1");
+    src1->set_pdu_data(make_endpoint_key("Robot1", "pos"), make_payload(1U, 16U));
+
+    auto src2 = std::make_shared<test_support::MockEndpoint>("src2");
+    auto dst2 = std::make_shared<test_support::MockEndpoint>("dst2");
+    src2->set_pdu_data(make_endpoint_key("Robot1", "status"), make_payload(1U, 16U));
+
+    core.add_connection(make_connection("node1", src1, dst1, "pos"));
+    core.add_connection(make_connection("node1", src2, dst2, "status"));
+
+    std::thread runner([&core]() { core.run(); });
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(5));
+    core.stop();
+    runner.join();
+
+    EXPECT_GT(dst1->send_count(make_endpoint_key("Robot1", "pos")), 0U);
+    EXPECT_GT(dst2->send_count(make_endpoint_key("Robot1", "status")), 0U);
+}
+
+} // namespace hako::pdu::bridge::test

--- a/test/bridge_loader_test.cpp
+++ b/test/bridge_loader_test.cpp
@@ -1,0 +1,48 @@
+#include "hakoniwa/pdu/bridge/bridge_loader.hpp"
+#include "hakoniwa/pdu/bridge/bridge_types.hpp"
+
+#include <gtest/gtest.h>
+
+#include <filesystem>
+#include <string>
+
+namespace hako::pdu::bridge::test {
+
+namespace {
+std::string config_path(const std::string& filename) {
+    return (std::filesystem::path(TEST_CONFIG_DIR) / filename).string();
+}
+} // namespace
+
+TEST(BridgeLoaderTest, LoadsImmediateConfig) {
+    BridgeConfig config = BridgeLoader::load_config(config_path("bridge-immediate.json"));
+
+    EXPECT_EQ(config.version, "2.0.0");
+    EXPECT_EQ(config.time_source_type, "virtual");
+    ASSERT_EQ(config.transferPolicies.size(), 1U);
+    EXPECT_EQ(config.transferPolicies.at("immediate_policy").type, "immediate");
+    EXPECT_FALSE(config.transferPolicies.at("immediate_policy").intervalMs.has_value());
+    EXPECT_EQ(config.nodes.size(), 1U);
+    EXPECT_EQ(config.endpoints.size(), 1U);
+    EXPECT_EQ(config.pduKeyGroups.at("group1").front().id, "Robot1.pos");
+}
+
+TEST(BridgeLoaderTest, LoadsThrottleConfig) {
+    BridgeConfig config = BridgeLoader::load_config(config_path("bridge-throttle.json"));
+
+    EXPECT_EQ(config.transferPolicies.at("throttle_policy").type, "throttle");
+    ASSERT_TRUE(config.transferPolicies.at("throttle_policy").intervalMs.has_value());
+    EXPECT_EQ(*config.transferPolicies.at("throttle_policy").intervalMs, 100);
+    EXPECT_EQ(config.connections.size(), 1U);
+}
+
+TEST(BridgeLoaderTest, LoadsTickerConfig) {
+    BridgeConfig config = BridgeLoader::load_config(config_path("bridge-ticker.json"));
+
+    EXPECT_EQ(config.transferPolicies.at("ticker_policy").type, "ticker");
+    ASSERT_TRUE(config.transferPolicies.at("ticker_policy").intervalMs.has_value());
+    EXPECT_EQ(*config.transferPolicies.at("ticker_policy").intervalMs, 50);
+    EXPECT_EQ(config.connections.front().transferPdus.front().policyId, "ticker_policy");
+}
+
+} // namespace hako::pdu::bridge::test

--- a/test/config/bridge-immediate.json
+++ b/test/config/bridge-immediate.json
@@ -1,0 +1,38 @@
+{
+  "version": "2.0.0",
+  "time_source_type": "virtual",
+  "transferPolicies": {
+    "immediate_policy": { "type": "immediate" }
+  },
+  "nodes": [
+    { "id": "node1" }
+  ],
+  "endpoints": [
+    {
+      "nodeId": "node1",
+      "endpoints": [
+        { "id": "node1-src", "mode": "local", "config_path": "config/endpoint1.json" },
+        { "id": "node1-dst", "mode": "wire", "config_path": "config/endpoint2.json" }
+      ]
+    }
+  ],
+  "wireLinks": [],
+  "pduKeyGroups": {
+    "group1": [
+      { "id": "Robot1.pos", "robot_name": "Robot1", "pdu_name": "pos" }
+    ]
+  },
+  "connections": [
+    {
+      "id": "conn1",
+      "nodeId": "node1",
+      "source": { "endpointId": "node1-src" },
+      "destinations": [
+        { "endpointId": "node1-dst" }
+      ],
+      "transferPdus": [
+        { "pduKeyGroupId": "group1", "policyId": "immediate_policy" }
+      ]
+    }
+  ]
+}

--- a/test/config/bridge-throttle.json
+++ b/test/config/bridge-throttle.json
@@ -1,0 +1,38 @@
+{
+  "version": "2.0.0",
+  "time_source_type": "virtual",
+  "transferPolicies": {
+    "throttle_policy": { "type": "throttle", "intervalMs": 100 }
+  },
+  "nodes": [
+    { "id": "node1" }
+  ],
+  "endpoints": [
+    {
+      "nodeId": "node1",
+      "endpoints": [
+        { "id": "node1-src", "mode": "local", "config_path": "config/endpoint1.json" },
+        { "id": "node1-dst", "mode": "wire", "config_path": "config/endpoint2.json" }
+      ]
+    }
+  ],
+  "wireLinks": [],
+  "pduKeyGroups": {
+    "group1": [
+      { "id": "Robot1.pos", "robot_name": "Robot1", "pdu_name": "pos" }
+    ]
+  },
+  "connections": [
+    {
+      "id": "conn1",
+      "nodeId": "node1",
+      "source": { "endpointId": "node1-src" },
+      "destinations": [
+        { "endpointId": "node1-dst" }
+      ],
+      "transferPdus": [
+        { "pduKeyGroupId": "group1", "policyId": "throttle_policy" }
+      ]
+    }
+  ]
+}

--- a/test/config/bridge-ticker.json
+++ b/test/config/bridge-ticker.json
@@ -1,0 +1,38 @@
+{
+  "version": "2.0.0",
+  "time_source_type": "virtual",
+  "transferPolicies": {
+    "ticker_policy": { "type": "ticker", "intervalMs": 50 }
+  },
+  "nodes": [
+    { "id": "node1" }
+  ],
+  "endpoints": [
+    {
+      "nodeId": "node1",
+      "endpoints": [
+        { "id": "node1-src", "mode": "local", "config_path": "config/endpoint1.json" },
+        { "id": "node1-dst", "mode": "wire", "config_path": "config/endpoint2.json" }
+      ]
+    }
+  ],
+  "wireLinks": [],
+  "pduKeyGroups": {
+    "group1": [
+      { "id": "Robot1.pos", "robot_name": "Robot1", "pdu_name": "pos" }
+    ]
+  },
+  "connections": [
+    {
+      "id": "conn1",
+      "nodeId": "node1",
+      "source": { "endpointId": "node1-src" },
+      "destinations": [
+        { "endpointId": "node1-dst" }
+      ],
+      "transferPdus": [
+        { "pduKeyGroupId": "group1", "policyId": "ticker_policy" }
+      ]
+    }
+  ]
+}

--- a/test/mock_endpoint.hpp
+++ b/test/mock_endpoint.hpp
@@ -1,0 +1,100 @@
+#pragma once
+
+#include "hakoniwa/pdu/endpoint.hpp"
+#include "hakoniwa/pdu/endpoint_types.hpp"
+
+#include <algorithm>
+#include <cstddef>
+#include <cstring>
+#include <mutex>
+#include <span>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace hako::pdu::bridge::test_support {
+
+class MockEndpoint : public hakoniwa::pdu::Endpoint {
+public:
+    explicit MockEndpoint(const std::string& name)
+        : hakoniwa::pdu::Endpoint(name, HAKO_PDU_ENDPOINT_DIRECTION_INOUT)
+        , name_(name) {
+    }
+
+    void set_pdu_data(const hakoniwa::pdu::PduKey& key, std::vector<std::byte> data) {
+        std::lock_guard<std::mutex> lock(mutex_);
+        const std::string map_key = make_key(key);
+        pdu_data_[map_key] = std::move(data);
+    }
+
+    size_t get_pdu_size(const hakoniwa::pdu::PduKey& key) const override {
+        std::lock_guard<std::mutex> lock(mutex_);
+        const std::string map_key = make_key(key);
+        auto it = pdu_data_.find(map_key);
+        if (it == pdu_data_.end()) {
+            return 0;
+        }
+        return it->second.size();
+    }
+
+    HakoPduErrorType recv(const hakoniwa::pdu::PduKey& key,
+                          std::span<std::byte> buffer,
+                          size_t& received_size) override {
+        std::lock_guard<std::mutex> lock(mutex_);
+        const std::string map_key = make_key(key);
+        auto it = pdu_data_.find(map_key);
+        if (it == pdu_data_.end()) {
+            received_size = 0;
+            return HAKO_PDU_ERR_OK;
+        }
+        received_size = std::min(buffer.size(), it->second.size());
+        std::memcpy(buffer.data(), it->second.data(), received_size);
+        return HAKO_PDU_ERR_OK;
+    }
+
+    HakoPduErrorType send(const hakoniwa::pdu::PduKey& key,
+                          std::span<const std::byte> buffer) override {
+        std::lock_guard<std::mutex> lock(mutex_);
+        const std::string map_key = make_key(key);
+        last_sent_data_[map_key] = std::vector<std::byte>(buffer.begin(), buffer.end());
+        send_counts_[map_key] += 1;
+        return HAKO_PDU_ERR_OK;
+    }
+
+    size_t send_count(const hakoniwa::pdu::PduKey& key) const {
+        std::lock_guard<std::mutex> lock(mutex_);
+        const std::string map_key = make_key(key);
+        auto it = send_counts_.find(map_key);
+        if (it == send_counts_.end()) {
+            return 0;
+        }
+        return it->second;
+    }
+
+    std::vector<std::byte> last_sent_data(const hakoniwa::pdu::PduKey& key) const {
+        std::lock_guard<std::mutex> lock(mutex_);
+        const std::string map_key = make_key(key);
+        auto it = last_sent_data_.find(map_key);
+        if (it == last_sent_data_.end()) {
+            return {};
+        }
+        return it->second;
+    }
+
+    const std::string& get_name() const override {
+        return name_;
+    }
+
+private:
+    static std::string make_key(const hakoniwa::pdu::PduKey& key) {
+        return key.robot + "." + key.pdu;
+    }
+
+    std::string name_;
+    mutable std::mutex mutex_;
+    std::unordered_map<std::string, std::vector<std::byte>> pdu_data_;
+    std::unordered_map<std::string, std::vector<std::byte>> last_sent_data_;
+    std::unordered_map<std::string, size_t> send_counts_;
+};
+
+} // namespace hako::pdu::bridge::test_support

--- a/test/transfer_pdu_test.cpp
+++ b/test/transfer_pdu_test.cpp
@@ -1,0 +1,119 @@
+#include "hakoniwa/pdu/bridge/policy/immediate_policy.hpp"
+#include "hakoniwa/pdu/bridge/policy/throttle_policy.hpp"
+#include "hakoniwa/pdu/bridge/policy/ticker_policy.hpp"
+#include "hakoniwa/pdu/bridge/transfer_pdu.hpp"
+#include "hakoniwa/pdu/bridge/virtual_time_source.hpp"
+#include "hakoniwa/pdu/endpoint_types.hpp"
+
+#include "mock_endpoint.hpp"
+
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <memory>
+#include <vector>
+
+namespace hako::pdu::bridge::test {
+
+namespace {
+std::vector<std::byte> make_payload(uint64_t epoch, size_t size) {
+    std::vector<std::byte> payload(size);
+    std::memcpy(payload.data(), &epoch, sizeof(epoch));
+    return payload;
+}
+
+hakoniwa::pdu::PduKey make_endpoint_key(const std::string& robot, const std::string& pdu) {
+    return hakoniwa::pdu::PduKey{robot, pdu};
+}
+
+PduKey make_config_key() {
+    return PduKey{"Robot1.pos", "Robot1", "pos"};
+}
+} // namespace
+
+TEST(TransferPduTest, ImmediatePolicyTransfersAndAcceptsEpoch) {
+    auto time_source = std::make_shared<VirtualTimeSource>();
+    auto policy = std::make_shared<ImmediatePolicy>();
+    auto src = std::make_shared<test_support::MockEndpoint>("src");
+    auto dst = std::make_shared<test_support::MockEndpoint>("dst");
+
+    auto payload = make_payload(1U, 16U);
+    src->set_pdu_data(make_endpoint_key("Robot1", "pos"), payload);
+
+    TransferPdu transfer_pdu(make_config_key(), policy, src, dst);
+    transfer_pdu.try_transfer(time_source);
+
+    EXPECT_EQ(dst->send_count(make_endpoint_key("Robot1", "pos")), 1U);
+    EXPECT_EQ(dst->last_sent_data(make_endpoint_key("Robot1", "pos")), payload);
+}
+
+TEST(TransferPduTest, ImmediatePolicyRejectsOlderEpoch) {
+    auto time_source = std::make_shared<VirtualTimeSource>();
+    auto policy = std::make_shared<ImmediatePolicy>();
+    auto src = std::make_shared<test_support::MockEndpoint>("src");
+    auto dst = std::make_shared<test_support::MockEndpoint>("dst");
+
+    auto payload = make_payload(1U, 16U);
+    src->set_pdu_data(make_endpoint_key("Robot1", "pos"), payload);
+
+    TransferPdu transfer_pdu(make_config_key(), policy, src, dst);
+    transfer_pdu.set_epoch(2U);
+    transfer_pdu.try_transfer(time_source);
+
+    EXPECT_EQ(dst->send_count(make_endpoint_key("Robot1", "pos")), 0U);
+}
+
+TEST(TransferPduTest, ThrottlePolicyTransfersOnInterval) {
+    auto time_source = std::make_shared<VirtualTimeSource>();
+    auto policy = std::make_shared<ThrottlePolicy>(std::chrono::milliseconds(100));
+    auto src = std::make_shared<test_support::MockEndpoint>("src");
+    auto dst = std::make_shared<test_support::MockEndpoint>("dst");
+
+    auto payload = make_payload(1U, 16U);
+    src->set_pdu_data(make_endpoint_key("Robot1", "pos"), payload);
+
+    TransferPdu transfer_pdu(make_config_key(), policy, src, dst);
+    transfer_pdu.try_transfer(time_source);
+    EXPECT_EQ(dst->send_count(make_endpoint_key("Robot1", "pos")), 1U);
+
+    transfer_pdu.try_transfer(time_source);
+    EXPECT_EQ(dst->send_count(make_endpoint_key("Robot1", "pos")), 1U);
+
+    time_source->advance_time(50'000U);
+    transfer_pdu.try_transfer(time_source);
+    EXPECT_EQ(dst->send_count(make_endpoint_key("Robot1", "pos")), 1U);
+
+    time_source->advance_time(50'000U);
+    transfer_pdu.try_transfer(time_source);
+    EXPECT_EQ(dst->send_count(make_endpoint_key("Robot1", "pos")), 2U);
+}
+
+TEST(TransferPduTest, TickerPolicyTransfersOnTicks) {
+    auto time_source = std::make_shared<VirtualTimeSource>();
+    auto policy = std::make_shared<TickerPolicy>(std::chrono::milliseconds(100));
+    auto src = std::make_shared<test_support::MockEndpoint>("src");
+    auto dst = std::make_shared<test_support::MockEndpoint>("dst");
+
+    auto payload = make_payload(1U, 16U);
+    src->set_pdu_data(make_endpoint_key("Robot1", "pos"), payload);
+
+    TransferPdu transfer_pdu(make_config_key(), policy, src, dst);
+    transfer_pdu.try_transfer(time_source);
+    EXPECT_EQ(dst->send_count(make_endpoint_key("Robot1", "pos")), 0U);
+
+    time_source->advance_time(100'000U);
+    transfer_pdu.try_transfer(time_source);
+    EXPECT_EQ(dst->send_count(make_endpoint_key("Robot1", "pos")), 1U);
+
+    transfer_pdu.try_transfer(time_source);
+    EXPECT_EQ(dst->send_count(make_endpoint_key("Robot1", "pos")), 1U);
+
+    time_source->advance_time(100'000U);
+    transfer_pdu.try_transfer(time_source);
+    EXPECT_EQ(dst->send_count(make_endpoint_key("Robot1", "pos")), 2U);
+}
+
+} // namespace hako::pdu::bridge::test


### PR DESCRIPTION
### Motivation
- Provide unit coverage for the bridge loader to validate `bridge.json` parsing and policy wiring. 
- Verify `TransferPdu` behavior with `immediate`/`throttle`/`ticker` policies and epoch acceptance logic. 
- Ensure `BridgeConnection::step()` correctly drives multiple `TransferPdu` instances. 
- Validate basic `BridgeCore::run()` loop processing across multiple connections.

### Description
- Added a `test/` test-suite with CMake integration and a test target `hakoniwa_pdu_bridge_tests` that defines `TEST_CONFIG_DIR` for fixtures. 
- Added bridge config fixtures `test/config/bridge-immediate.json`, `bridge-throttle.json`, and `bridge-ticker.json` and loader parsing tests exercising `BridgeLoader::load_config`. 
- Implemented a `MockEndpoint` in `test/mock_endpoint.hpp` and tests for `TransferPdu` exercising `TransferPdu::try_transfer` under `ImmediatePolicy`, `ThrottlePolicy`, and `TickerPolicy`, including epoch acceptance checks. 
- Added tests for `BridgeConnection::step()` and `BridgeCore::run()` to assert multiple connections and PDUs are stepped and transferred.

### Testing
- No automated tests were executed in this environment; the test target and GoogleTest-based cases were added but not run here. 
- The test suite is configured to run via CTest as `hakoniwa_pdu_bridge_tests` once built with the project. 
- Key methods exercised by tests are `BridgeLoader::load_config`, `TransferPdu::try_transfer`, `BridgeConnection::step`, and `BridgeCore::run`. 
- Test files added: `bridge_loader_test.cpp`, `transfer_pdu_test.cpp`, `bridge_connection_test.cpp`, and `bridge_core_test.cpp`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6950b46af85c8322b2bcc7f3b9726c5b)