### PR TITLE
Fix throttle policy initial transfer

### DIFF
--- a/include/hakoniwa/pdu/bridge/policy/throttle_policy.hpp
+++ b/include/hakoniwa/pdu/bridge/policy/throttle_policy.hpp
@@ -1,8 +1,9 @@
 #pragma once
 
 #include "hakoniwa/pdu/bridge/pdu_transfer_policy.hpp"
-#include <memory> // For std::shared_ptr
+#include <atomic>
 #include <chrono>
+#include <memory> // For std::shared_ptr
 
 namespace hako::pdu::bridge {
 
@@ -16,6 +17,7 @@ public:
 private:
     uint64_t interval_micros_;
     std::atomic<uint64_t> last_transfer_time_micros_;
+    std::atomic<bool> has_transferred_;
 };
 
 } // namespace hako::pdu::bridge

--- a/src/policy/throttle_policy.cpp
+++ b/src/policy/throttle_policy.cpp
@@ -4,9 +4,14 @@
 namespace hako::pdu::bridge {
 
 ThrottlePolicy::ThrottlePolicy(uint64_t interval_microseconds)
-    : interval_micros_(interval_microseconds), last_transfer_time_micros_(0) {}
+    : interval_micros_(interval_microseconds),
+      last_transfer_time_micros_(0),
+      has_transferred_(false) {}
 
 bool ThrottlePolicy::should_transfer(const std::shared_ptr<ITimeSource>& time_source) {
+    if (!has_transferred_.load()) {
+        return true;
+    }
     uint64_t now = time_source->get_microseconds();
     if ((now - last_transfer_time_micros_.load()) >= interval_micros_) {
         return true;
@@ -16,6 +21,7 @@ bool ThrottlePolicy::should_transfer(const std::shared_ptr<ITimeSource>& time_so
 
 void ThrottlePolicy::on_transferred(const std::shared_ptr<ITimeSource>& time_source) {
     last_transfer_time_micros_ = time_source->get_microseconds();
+    has_transferred_ = true;
 }
 
 } // namespace hako::pdu::bridge


### PR DESCRIPTION
### Motivation
- The `ThrottlePolicy` prevented the very first transfer from occurring because interval tracking started before any transfer was recorded.
- Tests and runtime expectations require the first `throttle`-policy transfer to be allowed immediately and then rate-limited afterward.

### Description
- Add an atomic flag `has_transferred_` to `ThrottlePolicy` to track whether any transfer has occurred.
- Update `should_transfer` to allow a transfer when `has_transferred_` is `false` and otherwise enforce the interval logic.
- Set `has_transferred_` to `true` in `on_transferred` after recording the last transfer time, and add necessary `#include <atomic>`.
- Changes made in `include/hakoniwa/pdu/bridge/policy/throttle_policy.hpp` and `src/policy/throttle_policy.cpp`.

### Testing
- Ran configuration step with `cmake -S . -B build`, which failed due to the missing `hakoniwa-pdu-endpoint` submodule `CMakeLists.txt` and missing GTest, so the build did not complete (failed).
- No unit tests were executed because the CMake configuration step failed to produce build targets.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6950bd2bc6848322901d1ea24bf3ce26)