### PR TITLE
Handle bridge build errors without exceptions

### DIFF
--- a/include/hakoniwa/pdu/bridge/bridge_build_result.hpp
+++ b/include/hakoniwa/pdu/bridge/bridge_build_result.hpp
@@ -10,6 +10,11 @@ namespace hakoniwa::pdu::bridge {
 
 struct BridgeBuildResult {
     std::unique_ptr<BridgeCore> core;
+    std::string error_message;
+
+    bool ok() const {
+        return core != nullptr;
+    }
 };
 
 } // namespace hakoniwa::pdu::bridge

--- a/include/hakoniwa/pdu/bridge/bridge_builder.hpp
+++ b/include/hakoniwa/pdu/bridge/bridge_builder.hpp
@@ -12,7 +12,7 @@ namespace hakoniwa::pdu::bridge {
 /*
  * just simply, loads the config file and converts to BridgeConfig
  */
-BridgeConfig parse(const std::string& config_file_path);
+std::optional<BridgeConfig> parse(const std::string& config_file_path, std::string& error_message);
 
 BridgeBuildResult build(const std::string& config_file_path, const std::string& node_name, uint64_t delta_time_step_usec, 
     std::shared_ptr<hakoniwa::pdu::EndpointContainer> endpoint_container);

--- a/src/bridge_builder.cpp
+++ b/src/bridge_builder.cpp
@@ -12,7 +12,6 @@
 #include <nlohmann/json.hpp> // nlohmann/json
 
 #include <fstream>
-#include <stdexcept>
 #include <filesystem>
 namespace fs = std::filesystem;
 
@@ -28,22 +27,36 @@ namespace hakoniwa::pdu::bridge {
         return (base_dir / p).lexically_normal();
     }
 
-    // Helper to parse BridgeConfig from file
-    BridgeConfig parse(const std::string& config_path) {
+    // Helper to parse BridgeConfig from file.
+    // NOTE: JSON exceptions are caught here and converted to error_message per exception-free policy.
+    std::optional<BridgeConfig> parse(const std::string& config_path, std::string& error_message) {
         std::ifstream ifs(config_path);
         if (!ifs.is_open()) {
-            throw std::runtime_error("BridgeLoader: Failed to open bridge config file: " + config_path);
+            error_message = "BridgeLoader: Failed to open bridge config file: " + config_path;
+            return std::nullopt;
         }
-        nlohmann::json j;
-        ifs >> j;
-        return j.get<BridgeConfig>();
+        nlohmann::json j = nlohmann::json::parse(ifs, nullptr, false);
+        if (j.is_discarded()) {
+            error_message = "BridgeLoader: Failed to parse bridge config JSON: " + config_path;
+            return std::nullopt;
+        }
+        try {
+            return j.get<BridgeConfig>();
+        } catch (const std::exception& e) {
+            error_message = std::string("BridgeLoader: Failed to decode bridge config: ") + e.what();
+            return std::nullopt;
+        }
     }
     BridgeBuildResult build(const std::string& config_file_path, const std::string& node_name, uint64_t delta_time_step_usec, std::shared_ptr<hakoniwa::pdu::EndpointContainer> endpoint_container)
     {
-        fs::path bridge_path(config_file_path);
-        fs::path base_dir = bridge_path.parent_path();
-
-        BridgeConfig bridge_config = parse(config_file_path);
+        BridgeBuildResult result;
+        std::string error_message;
+        auto maybe_config = parse(config_file_path, error_message);
+        if (!maybe_config) {
+            result.error_message = std::move(error_message);
+            return result;
+        }
+        const BridgeConfig& bridge_config = *maybe_config;
 
         /*
          * time source selection
@@ -68,14 +81,21 @@ namespace hakoniwa::pdu::bridge {
                 bool is_atomic = policy_def.atomic.value_or(false);
                 policy_map[id] = std::make_shared<ImmediatePolicy>(is_atomic);
             } else if (policy_def.type == "throttle") {
-                if (!policy_def.intervalMs) throw std::runtime_error("throttle policy needs intervalMs");
+                if (!policy_def.intervalMs) {
+                    result.error_message = "BridgeLoader: throttle policy needs intervalMs";
+                    return result;
+                }
                 policy_map[id] = std::make_shared<ThrottlePolicy>(static_cast<uint64_t>(*policy_def.intervalMs) * 1000); // Convert to microseconds
             } else if (policy_def.type == "ticker") {
-                if (!policy_def.intervalMs) throw std::runtime_error("ticker policy needs intervalMs");
+                if (!policy_def.intervalMs) {
+                    result.error_message = "BridgeLoader: ticker policy needs intervalMs";
+                    return result;
+                }
                 policy_map[id] = std::make_shared<TickerPolicy>(static_cast<uint64_t>(*policy_def.intervalMs) * 1000); // Convert to microseconds
             }
             else {
-                throw std::runtime_error("BridgeLoader: Unknown transfer policy type: " + policy_def.type);
+                result.error_message = "BridgeLoader: Unknown transfer policy type: " + policy_def.type;
+                return result;
             }
         }
 
@@ -90,23 +110,31 @@ namespace hakoniwa::pdu::bridge {
             
             std::shared_ptr<hakoniwa::pdu::Endpoint> src_ep = endpoint_container->ref(conn_def.source.endpointId);
             if (!src_ep) {
-                throw std::runtime_error("Source endpoint not found: " + conn_def.source.endpointId);
+                result.error_message = "BridgeLoader: Source endpoint not found: " + conn_def.source.endpointId;
+                return result;
             }
 
             for (const auto& dest_def : conn_def.destinations) {
                 std::shared_ptr<hakoniwa::pdu::Endpoint> dst_ep = endpoint_container->ref(dest_def.endpointId);
                 if (!dst_ep) {
-                    throw std::runtime_error("Destination endpoint not found: " + dest_def.endpointId);
+                    result.error_message = "BridgeLoader: Destination endpoint not found: " + dest_def.endpointId;
+                    return result;
                 }
 
                 for (const auto& trans_pdu_def : conn_def.transferPdus) {
                     auto pit = policy_map.find(trans_pdu_def.policyId);
                     if (pit == policy_map.end()) {
-                        throw std::runtime_error("Transfer policy not found: " + trans_pdu_def.policyId);
+                        result.error_message = "BridgeLoader: Transfer policy not found: " + trans_pdu_def.policyId;
+                        return result;
                     }
                     auto policy = pit->second;
 
-                    const auto& pdu_keys = bridge_config.pduKeyGroups.at(trans_pdu_def.pduKeyGroupId);
+                    auto key_group_it = bridge_config.pduKeyGroups.find(trans_pdu_def.pduKeyGroupId);
+                    if (key_group_it == bridge_config.pduKeyGroups.end()) {
+                        result.error_message = "BridgeLoader: PduKeyGroup not found: " + trans_pdu_def.pduKeyGroupId;
+                        return result;
+                    }
+                    const auto& pdu_keys = key_group_it->second;
 
                     for (const auto& pdu_key_def : pdu_keys) {
                         auto transfer_pdu = std::make_unique<TransferPdu>(pdu_key_def, policy, time_source, src_ep, dst_ep);
@@ -116,7 +144,8 @@ namespace hakoniwa::pdu::bridge {
             }
             core->add_connection(std::move(connection));
         }
-        return { std::move(core) };
+        result.core = std::move(core);
+        return result;
     }
 
 }

--- a/test/bridge_core_flow_test.cpp
+++ b/test/bridge_core_flow_test.cpp
@@ -23,6 +23,7 @@ TEST(BridgeCoreFlowTest, ImmediatePolicyFlow) {
     ASSERT_EQ(init_ret, HAKO_PDU_ERR_OK);
 
     auto result = hakoniwa::pdu::bridge::build(config_path("bridge-core-flow-test.json"), "node1", 1000, endpoint_container);
+    ASSERT_TRUE(result.ok()) << result.error_message;
     auto bridge_core = std::move(result.core);
 
     ASSERT_TRUE(bridge_core != nullptr);


### PR DESCRIPTION
### Motivation
- Follow the repository's exception-free policy by converting config parsing and build failures into returnable error values instead of throwing exceptions.
- Make bridge creation failure handling consistent with the runtime `daemon` startup flow so errors are reported and handled uniformly.
- Prevent uncontrolled JSON/decoding exceptions from escaping by bounding JSON parsing and decoding to the parsing layer.
- Improve robustness of CLI numeric parsing by replacing `std::stoull` with safe parsing via `std::from_chars`.

### Description
- Replace `parse()` with `std::optional<BridgeConfig> parse(const std::string&, std::string& error_message)` and convert JSON parse/decoding failures into `error_message` rather than throwing exceptions.
- Extend `BridgeBuildResult` with an `error_message` field and an `ok()` helper, and update `build()` to return `BridgeBuildResult` populated with either `core` or an error message for all validation failures (policies, key groups, endpoints).
- Update `src/daemon.cpp` to check `build_result.ok()` and print `build_result.error_message` on failure, and replace `std::stoull` with `std::from_chars` for safe `delta_time_step_usec` parsing.
- Adjust the test `test/bridge_core_flow_test.cpp` to assert `result.ok()` before using the returned `core`.

### Testing
- The test `test/bridge_core_flow_test.cpp` was updated to assert `result.ok()` and will fail fast if the builder returns an error message.
- No automated test suite was executed as part of this change (no tests were run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6960b06b2b3083229aaa01f2a813c936)