### PR TITLE
Add Ubuntu manifest build CI

### DIFF
--- a/.github/workflows/manifest-build-ubuntu.yml
+++ b/.github/workflows/manifest-build-ubuntu.yml
@@ -1,0 +1,121 @@
+name: Manifest Build (Ubuntu)
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  manifest-build:
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Checkout bridge
+        uses: actions/checkout@v4
+        with:
+          path: bridge
+
+      - name: Checkout pdu-endpoint
+        uses: actions/checkout@v4
+        with:
+          repository: hakoniwalab/hakoniwa-pdu-endpoint
+          path: pdu-endpoint
+
+      - name: Install build prerequisites
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y cmake g++ libboost-dev libgtest-dev
+
+      - name: Prepare endpoint CI manifest
+        working-directory: pdu-endpoint
+        run: |
+          cat > ci-build.yaml <<'EOF'
+          version: 1
+          build:
+            type: Release
+            dir: build-ci
+            shared: false
+            parallel: 2
+          bindings:
+            python: false
+          features:
+            hakoniwa_core: false
+            zenoh: false
+            mqtt: false
+          validation:
+            tests: false
+            examples: false
+            tools: false
+            benchmarks: false
+            python_import: false
+          paths:
+            hakoniwa_core_root: ""
+            vcpkg_root: ""
+          EOF
+
+      - name: Doctor endpoint
+        working-directory: pdu-endpoint
+        run: python3 tools/hako.py doctor --config ci-build.yaml
+
+      - name: Build endpoint
+        working-directory: pdu-endpoint
+        run: python3 tools/hako.py build --config ci-build.yaml
+
+      - name: Install endpoint
+        working-directory: pdu-endpoint
+        env:
+          ENDPOINT_PREFIX: ${{ runner.temp }}/hakoniwa-pdu-endpoint
+        run: cmake --install build-ci --prefix "$ENDPOINT_PREFIX"
+
+      - name: Prepare bridge CI manifest
+        working-directory: bridge
+        env:
+          ENDPOINT_PREFIX: ${{ runner.temp }}/hakoniwa-pdu-endpoint
+        run: |
+          cat > ci-build.yaml <<EOF
+          version: 1
+          build:
+            type: Release
+            dir: build-ci
+            parallel: 2
+          components:
+            library: true
+            standalone_app: true
+            hakoniwa_app: false
+            monitor: true
+          validation:
+            tests: true
+            examples: false
+            integration_tcp: false
+          paths:
+            pdu_endpoint_root: "$ENDPOINT_PREFIX"
+            hakoniwa_core_root: ""
+            vcpkg_root: ""
+          EOF
+
+      - name: Doctor bridge
+        working-directory: bridge
+        run: python3 tools/hako.py doctor --config ci-build.yaml
+
+      - name: Configure bridge
+        working-directory: bridge
+        run: python3 tools/hako.py configure --config ci-build.yaml
+
+      - name: Build bridge
+        working-directory: bridge
+        run: python3 tools/hako.py build --config ci-build.yaml
+
+      - name: Test bridge
+        working-directory: bridge
+        run: python3 tools/hako.py test --config ci-build.yaml
+
+      - name: Upload resolved build diagnostics
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: resolved-build-ubuntu
+          path: |
+            pdu-endpoint/.hako/
+            bridge/.hako/
+          if-no-files-found: ignore

--- a/.github/workflows/manifest-build-ubuntu.yml
+++ b/.github/workflows/manifest-build-ubuntu.yml
@@ -22,6 +22,12 @@ jobs:
           repository: hakoniwalab/hakoniwa-pdu-endpoint
           path: pdu-endpoint
 
+      - name: Checkout pdu-registry
+        uses: actions/checkout@v4
+        with:
+          repository: hakoniwalab/hakoniwa-pdu-registry
+          path: pdu-registry
+
       - name: Install build prerequisites
         run: |
           sudo apt-get update
@@ -96,18 +102,26 @@ jobs:
 
       - name: Doctor bridge
         working-directory: bridge
+        env:
+          HAKO_PDU_REGISTRY_ROOT: ${{ github.workspace }}/pdu-registry
         run: python3 tools/hako.py doctor --config ci-build.yaml
 
       - name: Configure bridge
         working-directory: bridge
+        env:
+          HAKO_PDU_REGISTRY_ROOT: ${{ github.workspace }}/pdu-registry
         run: python3 tools/hako.py configure --config ci-build.yaml
 
       - name: Build bridge
         working-directory: bridge
+        env:
+          HAKO_PDU_REGISTRY_ROOT: ${{ github.workspace }}/pdu-registry
         run: python3 tools/hako.py build --config ci-build.yaml
 
       - name: Test bridge
         working-directory: bridge
+        env:
+          HAKO_PDU_REGISTRY_ROOT: ${{ github.workspace }}/pdu-registry
         run: python3 tools/hako.py test --config ci-build.yaml
 
       - name: Upload resolved build diagnostics

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,31 +31,52 @@ set(HAKO_PDU_ENDPOINT_PREFIX "/usr/local/hakoniwa" CACHE PATH
 set(HAKO_PDU_BRIDGE_HAKONIWA_CORE_ROOT "${HAKO_PDU_ENDPOINT_PREFIX}" CACHE PATH
     "Install prefix of Hakoniwa Core used by Hakoniwa-integrated applications")
 
-find_path(HAKO_PDU_ENDPOINT_INCLUDE_DIR
-  NAMES hakoniwa/pdu/endpoint.hpp
+# Prefer the installed Endpoint CMake package. This preserves public usage
+# requirements such as HAKO_PDU_ENDPOINT_DISABLE_HAKONIWA_CORE and transitive
+# include/link requirements. Fall back to legacy header/library discovery for
+# older Endpoint installations that do not provide a package config.
+find_package(hakoniwa_pdu_endpoint CONFIG QUIET
   HINTS
-    "${HAKO_PDU_ENDPOINT_PREFIX}/include"
-    "/usr/local/include"
-    "/usr/local/hakoniwa/include"
-)
-find_library(HAKO_PDU_ENDPOINT_LIBRARY
-  NAMES hakoniwa_pdu_endpoint
-  HINTS
-    "${HAKO_PDU_ENDPOINT_PREFIX}/lib"
-    "${HAKO_PDU_ENDPOINT_PREFIX}/bin"
-    "/usr/local/lib"
-    "/usr/local/hakoniwa/lib"
+    "${HAKO_PDU_ENDPOINT_PREFIX}"
+    "${HAKO_PDU_ENDPOINT_PREFIX}/lib/cmake/hakoniwa_pdu_endpoint"
 )
 
-if(NOT HAKO_PDU_ENDPOINT_INCLUDE_DIR)
-  message(FATAL_ERROR "hakoniwa-pdu-endpoint header not found. Set HAKO_PDU_ENDPOINT_INCLUDE_DIR or HAKO_PDU_ENDPOINT_PREFIX.")
-endif()
-if(NOT HAKO_PDU_ENDPOINT_LIBRARY)
-  message(FATAL_ERROR "hakoniwa-pdu-endpoint library not found. Set HAKO_PDU_ENDPOINT_LIBRARY or HAKO_PDU_ENDPOINT_PREFIX.")
+set(HAKO_USING_ENDPOINT_PACKAGE OFF)
+if(TARGET hakoniwa_pdu_endpoint::hakoniwa_pdu_endpoint)
+  set(HAKO_USING_ENDPOINT_PACKAGE ON)
+  if(NOT TARGET hakoniwa_pdu_endpoint)
+    add_library(hakoniwa_pdu_endpoint ALIAS hakoniwa_pdu_endpoint::hakoniwa_pdu_endpoint)
+  endif()
+  message(STATUS "Using installed hakoniwa-pdu-endpoint CMake package from ${HAKO_PDU_ENDPOINT_PREFIX}")
 endif()
 
 set(HAKO_ENDPOINT_EXTRA_LIBS nlohmann_json::nlohmann_json)
 set(HAKO_PDU_BRIDGE_CORE_LIBS "")
+
+if(NOT HAKO_USING_ENDPOINT_PACKAGE)
+  find_path(HAKO_PDU_ENDPOINT_INCLUDE_DIR
+    NAMES hakoniwa/pdu/endpoint.hpp
+    HINTS
+      "${HAKO_PDU_ENDPOINT_PREFIX}/include"
+      "/usr/local/include"
+      "/usr/local/hakoniwa/include"
+  )
+  find_library(HAKO_PDU_ENDPOINT_LIBRARY
+    NAMES hakoniwa_pdu_endpoint
+    HINTS
+      "${HAKO_PDU_ENDPOINT_PREFIX}/lib"
+      "${HAKO_PDU_ENDPOINT_PREFIX}/bin"
+      "/usr/local/lib"
+      "/usr/local/hakoniwa/lib"
+  )
+
+  if(NOT HAKO_PDU_ENDPOINT_INCLUDE_DIR)
+    message(FATAL_ERROR "hakoniwa-pdu-endpoint header not found. Set HAKO_PDU_ENDPOINT_INCLUDE_DIR or HAKO_PDU_ENDPOINT_PREFIX.")
+  endif()
+  if(NOT HAKO_PDU_ENDPOINT_LIBRARY)
+    message(FATAL_ERROR "hakoniwa-pdu-endpoint library not found. Set HAKO_PDU_ENDPOINT_LIBRARY or HAKO_PDU_ENDPOINT_PREFIX.")
+  endif()
+endif()
 
 if(HAKO_PDU_BRIDGE_ENABLE_HAKONIWA_CORE)
   find_library(HAKO_ASSETS_LIBRARY

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,12 @@ set(HAKO_PDU_ENDPOINT_PREFIX "/usr/local/hakoniwa" CACHE PATH
     "Install prefix of hakoniwa-pdu-endpoint")
 set(HAKO_PDU_BRIDGE_HAKONIWA_CORE_ROOT "${HAKO_PDU_ENDPOINT_PREFIX}" CACHE PATH
     "Install prefix of Hakoniwa Core used by Hakoniwa-integrated applications")
+set(HAKO_PDU_REGISTRY_ROOT "" CACHE PATH
+    "Source checkout of hakoniwa-pdu-registry used by Bridge tests")
+if(HAKO_PDU_REGISTRY_ROOT STREQUAL "" AND DEFINED ENV{HAKO_PDU_REGISTRY_ROOT})
+  set(HAKO_PDU_REGISTRY_ROOT "$ENV{HAKO_PDU_REGISTRY_ROOT}" CACHE PATH
+      "Source checkout of hakoniwa-pdu-registry used by Bridge tests" FORCE)
+endif()
 
 # Prefer the installed Endpoint CMake package. This preserves public usage
 # requirements such as HAKO_PDU_ENDPOINT_DISABLE_HAKONIWA_CORE and transitive

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -18,6 +18,46 @@ target_include_directories(hakoniwa_pdu_bridge_tests
         ${CMAKE_CURRENT_SOURCE_DIR}
 )
 
+# PDU Registry is a test-only dependency. The production Bridge library remains
+# dependent only on hakoniwa-pdu-endpoint. Keep the historical hakoniwa/pdu/...
+# include spelling used by existing tests via a generated compatibility include
+# tree while sourcing the actual converter headers from the Registry checkout.
+if(HAKO_PDU_REGISTRY_ROOT)
+    set(HAKO_PDU_REGISTRY_TYPES_DIR "${HAKO_PDU_REGISTRY_ROOT}/pdu/types")
+    set(HAKO_PDU_REGISTRY_COMPAT_DIR "${CMAKE_CURRENT_BINARY_DIR}/pdu-registry-compat")
+
+    if(NOT EXISTS "${HAKO_PDU_REGISTRY_TYPES_DIR}/pdu_convertor.hpp")
+        message(FATAL_ERROR "PDU Registry pdu_convertor.hpp not found under ${HAKO_PDU_REGISTRY_TYPES_DIR}")
+    endif()
+    if(NOT EXISTS "${HAKO_PDU_REGISTRY_TYPES_DIR}/geometry_msgs/pdu_cpptype_conv_Twist.hpp")
+        message(FATAL_ERROR "PDU Registry Twist converter not found under ${HAKO_PDU_REGISTRY_TYPES_DIR}/geometry_msgs")
+    endif()
+
+    file(MAKE_DIRECTORY
+        "${HAKO_PDU_REGISTRY_COMPAT_DIR}/hakoniwa/pdu"
+        "${HAKO_PDU_REGISTRY_COMPAT_DIR}/hakoniwa/pdu/geometry_msgs"
+    )
+    configure_file(
+        "${HAKO_PDU_REGISTRY_TYPES_DIR}/pdu_convertor.hpp"
+        "${HAKO_PDU_REGISTRY_COMPAT_DIR}/hakoniwa/pdu/pdu_convertor.hpp"
+        COPYONLY
+    )
+    configure_file(
+        "${HAKO_PDU_REGISTRY_TYPES_DIR}/geometry_msgs/pdu_cpptype_conv_Twist.hpp"
+        "${HAKO_PDU_REGISTRY_COMPAT_DIR}/hakoniwa/pdu/geometry_msgs/pdu_cpptype_conv_Twist.hpp"
+        COPYONLY
+    )
+    target_include_directories(hakoniwa_pdu_bridge_tests PRIVATE
+        "${HAKO_PDU_REGISTRY_COMPAT_DIR}"
+        "${HAKO_PDU_REGISTRY_TYPES_DIR}"
+    )
+elseif(NOT HAKO_PDU_BRIDGE_ENABLE_HAKONIWA_CORE)
+    message(FATAL_ERROR
+        "Bridge tests require a hakoniwa-pdu-registry checkout when Hakoniwa Core is disabled. "
+        "Set HAKO_PDU_REGISTRY_ROOT or the HAKO_PDU_REGISTRY_ROOT environment variable."
+    )
+endif()
+
 target_compile_definitions(hakoniwa_pdu_bridge_tests
     PRIVATE
         TEST_CONFIG_DIR="${TEST_CONFIG_DIR}"

--- a/test/config/core_flow/cache/internal_queue.json
+++ b/test/config/core_flow/cache/internal_queue.json
@@ -1,9 +1,8 @@
 {
-  "type": "queue",
+  "type": "buffer",
   "name": "internal_fifo_queue",
   "store": {
     "mode": "queue",
-    "capacity": 10
+    "depth": 10
   }
 }
-


### PR DESCRIPTION
## Summary

Add the first CI validation for the manifest-driven build flow on a single proven platform: Ubuntu 24.04.

## Flow

1. check out `hakoniwa-pdu-endpoint`
2. build it with its manifest-driven `tools/hako.py` flow with Hakoniwa Core disabled
3. install it into a temporary prefix
4. point the Bridge manifest at that prefix
5. run Bridge `doctor`, `configure`, `build`, and `test`
6. upload `.hako/` resolved-build diagnostics on every run

## Scope

This intentionally does **not** add a multi-OS matrix yet. The purpose of this PR is to validate the dependency handoff and the new manifest build architecture in a clean CI environment before adding macOS or Windows.

`validation.integration_tcp` remains disabled for now; TCP smoke testing can be the next incremental CI step after this baseline is green.

## Dependencies

Ubuntu installs only the native prerequisites needed for this baseline: CMake, g++, Boost headers, and GTest.