### PR TITLE
Add staged TCP test control and macOS CI

### DIFF
--- a/.github/workflows/manifest-build-macos.yml
+++ b/.github/workflows/manifest-build-macos.yml
@@ -1,0 +1,139 @@
+name: Manifest Build (macOS)
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  manifest-build:
+    runs-on: macos-15
+
+    steps:
+      - name: Checkout bridge
+        uses: actions/checkout@v4
+        with:
+          path: bridge
+
+      - name: Checkout pdu-endpoint
+        uses: actions/checkout@v4
+        with:
+          repository: hakoniwalab/hakoniwa-pdu-endpoint
+          path: pdu-endpoint
+
+      - name: Checkout pdu-registry
+        uses: actions/checkout@v4
+        with:
+          repository: hakoniwalab/hakoniwa-pdu-registry
+          path: pdu-registry
+
+      - name: Install build prerequisites
+        run: brew install cmake boost googletest
+
+      - name: Prepare endpoint CI manifest
+        working-directory: pdu-endpoint
+        run: |
+          cat > ci-build.yaml <<'EOF'
+          version: 1
+          build:
+            type: Release
+            dir: build-ci
+            shared: false
+            parallel: 2
+          bindings:
+            python: false
+          features:
+            hakoniwa_core: false
+            zenoh: false
+            mqtt: false
+          validation:
+            tests: false
+            examples: false
+            tools: false
+            benchmarks: false
+            python_import: false
+          paths:
+            hakoniwa_core_root: ""
+            vcpkg_root: ""
+          EOF
+
+      - name: Doctor endpoint
+        working-directory: pdu-endpoint
+        run: python3 tools/hako.py doctor --config ci-build.yaml
+
+      - name: Build endpoint
+        working-directory: pdu-endpoint
+        run: python3 tools/hako.py build --config ci-build.yaml
+
+      - name: Install endpoint
+        working-directory: pdu-endpoint
+        env:
+          ENDPOINT_PREFIX: ${{ runner.temp }}/hakoniwa-pdu-endpoint
+        run: cmake --install build-ci --prefix "$ENDPOINT_PREFIX"
+
+      - name: Prepare bridge CI manifest
+        working-directory: bridge
+        env:
+          ENDPOINT_PREFIX: ${{ runner.temp }}/hakoniwa-pdu-endpoint
+        run: |
+          cat > ci-build.yaml <<EOF
+          version: 1
+          build:
+            type: Release
+            dir: build-ci
+            parallel: 2
+          components:
+            library: true
+            standalone_app: true
+            hakoniwa_app: false
+            monitor: true
+          validation:
+            tests: true
+            examples: false
+            integration_tcp: false
+          paths:
+            pdu_endpoint_root: "$ENDPOINT_PREFIX"
+            hakoniwa_core_root: ""
+            vcpkg_root: ""
+          EOF
+
+      - name: Doctor bridge
+        working-directory: bridge
+        env:
+          HAKO_PDU_REGISTRY_ROOT: ${{ github.workspace }}/pdu-registry
+        run: python3 tools/hako.py doctor --config ci-build.yaml
+
+      - name: Configure bridge
+        working-directory: bridge
+        env:
+          HAKO_PDU_REGISTRY_ROOT: ${{ github.workspace }}/pdu-registry
+        run: python3 tools/hako.py configure --config ci-build.yaml
+
+      - name: Enable TCP integration tests
+        working-directory: bridge
+        env:
+          HAKO_PDU_REGISTRY_ROOT: ${{ github.workspace }}/pdu-registry
+        run: cmake -S . -B build-ci -DHAKO_PDU_BRIDGE_BUILD_TCP_TESTS=ON
+
+      - name: Build bridge
+        working-directory: bridge
+        env:
+          HAKO_PDU_REGISTRY_ROOT: ${{ github.workspace }}/pdu-registry
+        run: python3 tools/hako.py build --config ci-build.yaml
+
+      - name: Test bridge
+        working-directory: bridge
+        env:
+          HAKO_PDU_REGISTRY_ROOT: ${{ github.workspace }}/pdu-registry
+        run: python3 tools/hako.py test --config ci-build.yaml
+
+      - name: Upload resolved build diagnostics
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: resolved-build-macos
+          path: |
+            pdu-endpoint/.hako/
+            bridge/.hako/
+          if-no-files-found: ignore

--- a/.github/workflows/manifest-build-ubuntu.yml
+++ b/.github/workflows/manifest-build-ubuntu.yml
@@ -112,6 +112,12 @@ jobs:
           HAKO_PDU_REGISTRY_ROOT: ${{ github.workspace }}/pdu-registry
         run: python3 tools/hako.py configure --config ci-build.yaml
 
+      - name: Enable TCP integration tests
+        working-directory: bridge
+        env:
+          HAKO_PDU_REGISTRY_ROOT: ${{ github.workspace }}/pdu-registry
+        run: cmake -S . -B build-ci -DHAKO_PDU_BRIDGE_BUILD_TCP_TESTS=ON
+
       - name: Build bridge
         working-directory: bridge
         env:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,7 @@ option(HAKO_PDU_BRIDGE_BUILD_STANDALONE_APP "Build standalone bridge daemon" ON)
 option(HAKO_PDU_BRIDGE_BUILD_HAKONIWA_APP "Build Hakoniwa-integrated web bridge daemon" ON)
 option(HAKO_PDU_BRIDGE_BUILD_MONITOR "Build bridge monitor CLI" ON)
 option(HAKO_PDU_BRIDGE_BUILD_TESTS "Build bridge tests" ON)
+option(HAKO_PDU_BRIDGE_BUILD_TCP_TESTS "Build TCP cross-node integration tests" OFF)
 option(HAKO_PDU_BRIDGE_BUILD_EXAMPLES "Build bridge examples" ON)
 option(HAKO_PDU_BRIDGE_ENABLE_HAKONIWA_CORE "Resolve/link Hakoniwa Core runtime libraries" ON)
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -5,11 +5,16 @@ set(TEST_CONFIG_DIR "${CMAKE_CURRENT_SOURCE_DIR}/config" CACHE PATH "Test config
 set(TEST_SOURCES
     bridge_loader_test.cpp
     bridge_core_flow_test.cpp
-    bridge_tcp_flow_test.cpp
     bridge_connection_test.cpp
     ondemand_control_handler_test.cpp
     monitor_cli_utils_test.cpp
 )
+
+# Keep the default test suite deterministic and transport-independent. TCP flow
+# tests are integration tests and must be enabled explicitly.
+if(HAKO_PDU_BRIDGE_BUILD_TCP_TESTS)
+    list(APPEND TEST_SOURCES bridge_tcp_flow_test.cpp)
+endif()
 
 add_executable(hakoniwa_pdu_bridge_tests ${TEST_SOURCES})
 


### PR DESCRIPTION
## Summary

Add an explicit TCP integration-test switch so platform bring-up can be staged, while keeping Ubuntu and macOS on the full baseline + TCP validation path.

## Why

Internal cache tests provide the smallest deterministic CI baseline. TCP cross-node tests are also valuable and already pass on Ubuntu, so Linux and macOS should run them by default. Windows will use the new switch for a two-stage bring-up: first validate the Core-independent internal-cache path, then enable TCP once the base build is stable.

## Changes

- add `HAKO_PDU_BRIDGE_BUILD_TCP_TESTS`, default `OFF`
- keep TCP cross-node tests separate from the baseline test source list
- explicitly enable TCP tests in Ubuntu CI
- add macOS 15 / Apple Silicon CI
- macOS builds and installs `hakoniwa-pdu-endpoint` with Hakoniwa Core disabled
- macOS checks out `hakoniwa-pdu-registry` for test-only converter headers
- macOS runs Bridge baseline tests and TCP cross-node tests

## Platform policy

- Ubuntu: baseline + TCP
- macOS: baseline + TCP
- Windows stage 1: baseline only
- Windows stage 2: baseline + TCP

The manifest-level `validation.integration_tcp` wiring remains reserved for a follow-up cleanup; this PR uses the CMake switch explicitly in CI so the platform-validation policy is visible and controllable now.