### PR TITLE
Enable Windows TCP integration tests

### DIFF
--- a/.github/workflows/manifest-build-windows.yml
+++ b/.github/workflows/manifest-build-windows.yml
@@ -115,13 +115,19 @@ jobs:
           HAKO_PDU_REGISTRY_ROOT: ${{ github.workspace }}\pdu-registry
         run: python tools/hako.py configure --config ci-build.yaml
 
+      - name: Enable TCP integration tests
+        working-directory: bridge
+        env:
+          HAKO_PDU_REGISTRY_ROOT: ${{ github.workspace }}\pdu-registry
+        run: cmake -S . -B build-ci -DHAKO_PDU_BRIDGE_BUILD_TCP_TESTS=ON
+
       - name: Build bridge
         working-directory: bridge
         env:
           HAKO_PDU_REGISTRY_ROOT: ${{ github.workspace }}\pdu-registry
         run: python tools/hako.py build --config ci-build.yaml
 
-      - name: Test bridge baseline
+      - name: Test bridge baseline and TCP
         working-directory: bridge
         env:
           HAKO_PDU_REGISTRY_ROOT: ${{ github.workspace }}\pdu-registry


### PR DESCRIPTION
## Summary

Enable the TCP cross-node integration tests in the Windows manifest CI now that the Core-independent Windows baseline is stable.

## Context

Windows bring-up was intentionally staged:

1. Endpoint + Bridge baseline with Hakoniwa Core disabled and TCP tests OFF
2. Enable TCP integration once MSVC/vcpkg/package-install issues were resolved

Stage 1 is now passing on Windows. Ubuntu and macOS already run the same baseline + TCP test path successfully.

## Changes

- keep the existing Windows manifest baseline unchanged
- after Bridge configure, explicitly reconfigure with `HAKO_PDU_BRIDGE_BUILD_TCP_TESTS=ON`
- run the normal test command so both baseline and TCP tests execute
- rename the test step to make the expanded coverage visible in CI

## Expected result

Windows should now validate:

- Core-independent Endpoint build/install
- Core-independent Bridge build
- internal-cache baseline tests
- TCP cross-node Bridge flow tests

This completes the three-platform baseline + TCP CI matrix for Ubuntu, macOS, and Windows.